### PR TITLE
Optimizations to preallocate arrays based on expected size.

### DIFF
--- a/Ebcdic2Unicode/EbcdicParser.cs
+++ b/Ebcdic2Unicode/EbcdicParser.cs
@@ -53,7 +53,7 @@ namespace Ebcdic2Unicode
             }
 
             byte[] lineBytes = new byte[lineTemplate.LineSize];
-            List<ParsedLine> linesList = new List<ParsedLine>();
+            ParsedLine[] linesList = new ParsedLine[Convert.ToInt32(expectedRows)];
             ParsedLine parsedLine = null;
             int lineIndex = 0;
 
@@ -67,7 +67,7 @@ namespace Ebcdic2Unicode
 
                     if (parsedLine != null)
                     {
-                        linesList.Add(parsedLine);
+                        linesList[lineIndex] = parsedLine;
                     }
 
                     lineIndex++;
@@ -85,7 +85,7 @@ namespace Ebcdic2Unicode
                 }
             }
             Console.WriteLine("{1}: {0} line(s) have been parsed", linesList.Count(), DateTime.Now);
-            return linesList.ToArray();
+            return linesList;
         }
 
         /// <summary>

--- a/Ebcdic2Unicode/ParsedLine.cs
+++ b/Ebcdic2Unicode/ParsedLine.cs
@@ -31,7 +31,7 @@ namespace Ebcdic2Unicode
         //Constructor
         public ParsedLine(LineTemplate template, byte[] lineBytes)
         {
-            this.ParsedFields = new Dictionary<string, ParsedField>();
+            this.ParsedFields = new Dictionary<string, ParsedField>(template.FieldsCount);
             this.Template = template;
             this.ParseLine(lineBytes, template);
         }


### PR DESCRIPTION
Hello Max-

First off, thank you for sharing this library.  It saved us a TON of time and works great.  I was wondering if you'd consider accepting these 2 minor optimizations in your base code.  We found when working with large files (hundreds of MB or even over a GB) that these can make a fairly significant difference - mainly the ParsedLine() change when your template has a large number of fields - but both changes help to keep the array resizing to a minimum.

Also just FYI, I didn't include it in the PR, but we also found it necessary to run the application in 64bit mode (don't forget to uncheck Prefer 32bit in the project properties) and add the following setting to the app.config to bypass the 2GB memory limitation: 
````xml
    <gcAllowVeryLargeObjects enabled="true" />
````

Mainly mentioning it for the benefit of others.

Thanks again-
